### PR TITLE
chore: lint with `jarl`

### DIFF
--- a/R/asd_sco_binary_format.R
+++ b/R/asd_sco_binary_format.R
@@ -40,7 +40,7 @@ ASDScoBinary <- R6::R6Class("ASDScoBinary",
 
          spec.df <-
             data.frame(wavenumber=as.integer(rownames(spec.data)),
-                       intensity=spec.data[1:length(spec.data)])
+                       intensity=spec.data[seq_along(spec.data)])
 
          meta.list <- list()
          meta.list[["name"]] <- colnames(spec.data)

--- a/R/nicolet_spa_format.R
+++ b/R/nicolet_spa_format.R
@@ -66,9 +66,9 @@ key.value.pairs <- function(path) {
 
   for (str in strings.from.spa(path)) {
     delimiter <- NULL
-    if (grepl(str, pattern="=")) {
+    if (grepl(str, pattern="=", fixed = TRUE)) {
       delimiter <- "="
-    } else if (grepl(str, pattern=":")) {
+    } else if (grepl(str, pattern=":", fixed = TRUE)) {
       delimiter <- ":"
     }
 

--- a/R/parse_raw_file_for_reading.R
+++ b/R/parse_raw_file_for_reading.R
@@ -26,7 +26,7 @@ if(!dir.exists(out.directory)){dir.create(out.directory)}
 
   SpecSets <- unique(indf$SampleSpectrumSetId)
 
-  for(i in 1:length(SpecSets)){
+  for(i in seq_along(SpecSets)){
     print(paste0('Processing Spectral Set ', i, ' of ', length(SpecSets)))
     specid <- SpecSets[i]
     idxs <- which(indf$SampleSpectrumSetId==specid)
@@ -39,11 +39,11 @@ if(!dir.exists(out.directory)){dir.create(out.directory)}
     idxS <-  which(specdf$Type=='SAMPLE')
     sampDF <- specdf[idxS,]
 
-    for (j in 1:nrow(sampDF)) {
-      srec = sampDF[j,]
+    for (j in seq_len(nrow(sampDF))) {
+      srec <- sampDF[j,]
       #brec = specdf[1,]
 
-      fname = paste0(srec$'Sample ID', '_', srec$SampleSpectrumSetId, '_', srec$SpectrumId)
+      fname <- paste0(srec$'Sample ID', '_', srec$SampleSpectrumSetId, '_', srec$SpectrumId)
       odf <- rbind(bkgDF, srec)
       write.csv(odf, paste0(out.directory, '/', fname, '.hlr'), row.names = F)
 
@@ -93,7 +93,7 @@ parse.scans <- function(path, out.directory) {
 
   indf <- read.csv(path, header = T, check.names=F)
 
-  for(i in 1:nrow(indf)){
+  for(i in seq_len(nrow(indf))){
     rec <- indf[i,]
     print(paste0('Processing Spectra ', i, ' of ', nrow(indf)))
     specid <- paste0( rec$core.label, '_',  rec$core_position)


### PR DESCRIPTION
do

```sh
jarl check R/ --fix
```

details here: https://r-consortium.org/posts/jarl-just-another-r-linter/

locally, I used this linting env using nix:

```nix
let
  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz") {};

  # Override jarl to skip failing tests
  jarl = pkgs.jarl.overrideAttrs (oldAttrs: {
    doCheck = false;
  });

  rpkgs = builtins.attrValues {
    inherit (pkgs.rPackages)
      asdreader
      hyperSpec
      jsonlite
      knitr
      prospectr
      R6
      Rcpp
      rmarkdown
      stringr
      geometry
      clhs
      testthat
      devtools
      roxygen2
      lintr
      styler;
  };

  system_packages = builtins.attrValues {
    inherit (pkgs)
      R
      glibcLocalesUtf8;
  } ++ [ jarl ];
in

pkgs.mkShell {
  LOCALE_ARCHIVE = if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then "${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive" else "";
  LANG = "en_US.UTF-8";
  LC_ALL = "en_US.UTF-8";
  LC_TIME = "en_US.UTF-8";
  LC_MONETARY = "en_US.UTF-8";
  LC_PAPER = "en_US.UTF-8";
  LC_MEASUREMENT = "en_US.UTF-8";

  buildInputs = [ system_packages rpkgs ];

}

```